### PR TITLE
[FIX kbss-cvut/fta-fmea-ui#226] Fix reading fault event properties in fault tree

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/model/FaultEvent.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/FaultEvent.java
@@ -73,6 +73,23 @@ public class FaultEvent extends Event {
     public void addChildren(Set<FaultEvent> children){getChildren().addAll(children);}
     public void addChildSequenceUri(URI childUri) {getChildrenSequence().add(childUri);}
 
+    public Set<FaultEvent> getAllEventParts(){
+        Stack<FaultEvent> stack = new Stack<>();
+        stack.push(this);
+        Set<FaultEvent> result = new HashSet<>();
+        while(!stack.isEmpty()){
+            FaultEvent f = stack.pop();
+            if(!result.add(f))
+                continue;
+
+            if(f.getChildren() == null || f.getChildren().isEmpty())
+                continue;
+
+            f.getChildren().forEach(stack::push);
+        }
+        return result;
+    }
+
     @Override
     public String toString() {
         return "FaultEvent <" + getUri() + "/>";

--- a/src/main/java/cz/cvut/kbss/analysis/model/FaultTree.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/FaultTree.java
@@ -6,7 +6,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 @OWLClass(iri = Vocabulary.s_c_fault_tree)
@@ -24,6 +26,12 @@ public class FaultTree extends NamedEntity {
 
     @OWLObjectProperty(iri = Vocabulary.s_p_has_scenario, cascade = {CascadeType.MERGE}, fetch = FetchType.EAGER)
     private Set<FaultEventScenario> faultEventScenarios;
+
+    public Set<FaultEvent> getAllEvents(){
+        return Optional.ofNullable(getManifestingEvent())
+                .filter(e -> e != null)
+                .map(e -> e.getAllEventParts()).orElse(new HashSet<>());
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/cz/cvut/kbss/analysis/service/FaultTreeRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FaultTreeRepositoryService.java
@@ -64,6 +64,23 @@ public class FaultTreeRepositoryService extends BaseRepositoryService<FaultTree>
         persist(faultTree);
     }
 
+    @Override
+    public FaultTree findRequired(URI id) {
+        FaultTree ft = super.findRequired(id);
+        // remove component children
+        Set<Item> items = ft.getAllEvents().stream().map(e -> e.getSupertypes())
+                .filter(ts -> ts!= null)
+                .flatMap(ts -> ts.stream())
+                .map(Event::getBehavior)
+                .filter(ts -> ts!= null)
+                .map(Behavior::getItem)
+                .filter(c -> c != null).collect(Collectors.toSet());
+        for(Item i : items){
+            items.forEach(c -> c.setComponents(null));
+        }
+        return ft;
+    }
+
     @Transactional
     public FaultTree findWithPropagation(URI faultTreeUri) {
         log.info("> findWithPropagation - {}", faultTreeUri);


### PR DESCRIPTION
Fixes kbss-cvut/fta-fmea-ui#226
- fix in fault tree entity descriptor
- explicitly read lazy relations
- remove unnecessary eager relations before returning response