### PR TITLE
Add language tag only for language strings

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/model/Behavior.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/Behavior.java
@@ -17,7 +17,7 @@ public abstract class Behavior extends DomainEntity<Behavior> {
     @OWLObjectProperty(iri = Vocabulary.s_p_is_derived_from, fetch = FetchType.EAGER)
     protected Set<Behavior> supertypes;
 
-    @OWLDataProperty(iri = Vocabulary.s_p_behavior_type)
+    @OWLDataProperty(iri = Vocabulary.s_p_behavior_type, simpleLiteral = true)
     private BehaviorType behaviorType = BehaviorType.AtomicBehavior;
 
     @OWLObjectProperty(iri = Vocabulary.s_p_has_required, fetch = FetchType.EAGER)

--- a/src/main/java/cz/cvut/kbss/analysis/model/DomainEntity.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/DomainEntity.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @Setter
 public abstract class DomainEntity<T extends DomainEntity> extends ManagedEntity{
 
-    @OWLDataProperty(iri = Vocabulary.s_p_has_type_category)
+    @OWLDataProperty(iri = Vocabulary.s_p_has_type_category, simpleLiteral = true)
     private TypeCategory typeCategory;
 
     public abstract Set<T> getSupertypes();

--- a/src/main/java/cz/cvut/kbss/analysis/model/FailureMode.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/FailureMode.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 public class FailureMode extends Behavior {
 
-    @OWLDataProperty(iri = Vocabulary.s_p_failure_mode_type)
+    @OWLDataProperty(iri = Vocabulary.s_p_failure_mode_type, simpleLiteral = true)
     private FailureModeType failureModeType = FailureModeType.FailureMode;
 
     @Override

--- a/src/main/java/cz/cvut/kbss/analysis/model/FaultEvent.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/FaultEvent.java
@@ -39,10 +39,10 @@ public class FaultEvent extends Event {
 
     @NotNull(message = "EventType must be defined")
     @ParticipationConstraints(nonEmpty = true)
-    @OWLDataProperty(iri = Vocabulary.s_p_fault_event_type)
+    @OWLDataProperty(iri = Vocabulary.s_p_fault_event_type, simpleLiteral = true)
     private FtaEventType eventType;
 
-    @OWLDataProperty(iri = Vocabulary.s_p_gate_type)
+    @OWLDataProperty(iri = Vocabulary.s_p_gate_type, simpleLiteral = true)
     private GateType gateType;
 
     @OWLObjectProperty(iri = Vocabulary.s_p_has_rectangle, fetch = FetchType.EAGER, cascade = CascadeType.ALL)

--- a/src/main/java/cz/cvut/kbss/analysis/model/User.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/User.java
@@ -27,13 +27,13 @@ public class User extends AbstractEntity implements UserDetails {
 
     @NotEmpty(message = "Username must not be empty")
     @ParticipationConstraints(nonEmpty = true)
-    @OWLDataProperty(iri = Vocabulary.s_p_username)
+    @OWLDataProperty(iri = Vocabulary.s_p_username, simpleLiteral = true)
     private String username;
 
     @NotEmpty(message = "Password must not be empty")
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @ParticipationConstraints(nonEmpty = true)
-    @OWLDataProperty(iri = Vocabulary.s_p_password)
+    @OWLDataProperty(iri = Vocabulary.s_p_password, simpleLiteral = true)
     private String password;
 
     @Transient

--- a/src/main/java/cz/cvut/kbss/analysis/model/ava/ATASystem.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/ava/ATASystem.java
@@ -1,8 +1,6 @@
 package cz.cvut.kbss.analysis.model.ava;
 
 import cz.cvut.kbss.analysis.model.Component;
-import cz.cvut.kbss.analysis.model.Item;
-import cz.cvut.kbss.analysis.model.System;
 import cz.cvut.kbss.analysis.util.Vocabulary;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
@@ -17,7 +15,7 @@ import lombok.Setter;
 @Setter
 public class ATASystem extends Component {
 
-    @OWLDataProperty(iri = Vocabulary.s_p_ata_code)
+    @OWLDataProperty(iri = Vocabulary.s_p_ata_code, simpleLiteral = true)
     private String ataCode;
 
 }

--- a/src/main/java/cz/cvut/kbss/analysis/model/ava/FHAEventType.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/ava/FHAEventType.java
@@ -22,6 +22,6 @@ public class FHAEventType extends FaultEventType {
     @OWLObjectProperty(iri = Vocabulary.s_c_verification_method)
     private Set<VerificationMethod> verificationMethods;
 
-    @OWLDataProperty(iri = Vocabulary.s_p_material_reference)
+    @OWLDataProperty(iri = Vocabulary.s_p_material_reference, simpleLiteral = true)
     private Set<String> referencedMaterials;
 }

--- a/src/main/java/cz/cvut/kbss/analysis/model/ava/IndependentSNSItem.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/ava/IndependentSNSItem.java
@@ -17,9 +17,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class IndependentSNSItem extends Item {
-    @OWLDataProperty(iri = Vocabulary.s_p_part_number)
+    @OWLDataProperty(iri = Vocabulary.s_p_part_number, simpleLiteral = true)
     private String partNumber;
 
-    @OWLDataProperty(iri = Vocabulary.s_p_stock)
+    @OWLDataProperty(iri = Vocabulary.s_p_stock, simpleLiteral = true)
     private String stock;
 }

--- a/src/main/java/cz/cvut/kbss/analysis/model/ava/SNSComponent.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/ava/SNSComponent.java
@@ -21,7 +21,7 @@ public class SNSComponent extends Component {
     @OWLDataProperty(iri = Vocabulary.s_p_quantity)
     private Integer quantity;
 
-    @OWLDataProperty(iri = Vocabulary.s_p_schematic_designation)
+    @OWLDataProperty(iri = Vocabulary.s_p_schematic_designation, simpleLiteral = true)
     private Set<String> schematicDescription;
 
 }

--- a/src/main/java/cz/cvut/kbss/analysis/model/method/EstimationMethod.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/method/EstimationMethod.java
@@ -7,6 +7,6 @@ import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
 
 @OWLClass(iri = Vocabulary.s_c_failure_rate_general_estimation_method)
 public class EstimationMethod extends NamedEntity {
-    @OWLDataProperty(iri = Vocabulary.s_p_code)
+    @OWLDataProperty(iri = Vocabulary.s_p_code, simpleLiteral = true)
     public String code;
 }

--- a/src/main/java/cz/cvut/kbss/analysis/model/method/VerificationMethod.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/method/VerificationMethod.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class VerificationMethod extends NamedEntity {
-    @OWLDataProperty(iri = Vocabulary.s_p_code)
+    @OWLDataProperty(iri = Vocabulary.s_p_code, simpleLiteral = true)
     public String code;
 }


### PR DESCRIPTION
@blcham 
See kbss-cvut/fta-fmea-ui#284

Implemented by adding simpleLiteral=true for non language strings fields (such as password and ataCode) and enum fields (such as gateType and behaviorType).