### PR TITLE
Fix/106 cant fetch fault tree after update

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/controller/FaultTreeController.java
+++ b/src/main/java/cz/cvut/kbss/analysis/controller/FaultTreeController.java
@@ -39,7 +39,7 @@ public class FaultTreeController {
     public FaultTree find(@PathVariable(name = "faultTreeFragment") String faultTreeFragment) {
         log.info("> find - {}", faultTreeFragment);
         URI faultTreeUri = identifierService.composeIdentifier(Vocabulary.s_c_fault_tree, faultTreeFragment);
-        return repositoryService.findRequired(faultTreeUri);
+        return repositoryService.findWithDetails(faultTreeUri);
     }
 
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/cz/cvut/kbss/analysis/dao/ManagedEntityDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/ManagedEntityDao.java
@@ -2,7 +2,8 @@ package cz.cvut.kbss.analysis.dao;
 
 import cz.cvut.kbss.analysis.config.conf.PersistenceConf;
 import cz.cvut.kbss.analysis.exception.PersistenceException;
-import cz.cvut.kbss.analysis.model.*;
+import cz.cvut.kbss.analysis.model.ManagedEntity;
+import cz.cvut.kbss.analysis.model.UserReference;
 import cz.cvut.kbss.analysis.service.IdentifierService;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
 import cz.cvut.kbss.analysis.util.Vocabulary;
@@ -49,7 +50,7 @@ public class ManagedEntityDao<T extends ManagedEntity> extends NamedEntityDao<T>
                 DELETE{
                     GRAPH ?context{ 
                         ?uri ?pModified ?lastModified. 
-                        ?uri ?pLastEditor ?lastEditor. 
+                        ?uri ?pLastEditor ?lastEditorURI. 
                     }
                 }INSERT{
                     GRAPH ?context{


### PR DESCRIPTION
@blcham 
Fixes #106

@LaChope 
To fix the broken fault tree go to the db-server, select the fta-fmea repository find and open the context containing the problematic fault tree, there should be 2 editors `fta:editor` . Deleting one of the `fta:editor` triples (e.g. the one corresponding to your user) should enable the fault tree to be fetched. 