### PR TITLE
fta-fmea-ui#352 Fix api for updating fault events

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/service/FaultEventRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FaultEventRepositoryService.java
@@ -165,6 +165,14 @@ public class FaultEventRepositoryService extends BaseRepositoryService<FaultEven
         log.info("< updateChildrenSequence");
     }
 
+    @Override
+    protected void preUpdate(FaultEvent instance) {
+        if(instance.getSupertypes() != null && !instance.getSupertypes().isEmpty())
+            faultEventDao.loadManagedSupertypes(instance);
+
+        super.preUpdate(instance);
+    }
+
     @Transactional
     public void update(Rectangle rect){
         faultEventDao.update(rect);


### PR DESCRIPTION
@blcham 
Contributes to kbss-cvut/fta-fmea-ui#352
The API takes as input parameter fault tree URI fragment and filters the fault tree's root event type from the list.
The backend does not reorder the list of event types. 
