### PR TITLE
fta-fmea-ui#310 Implement persistent minimal operational and integration into API

### DIFF
--- a/ontology-generator/ontology/fta-fmea-model.ttl
+++ b/ontology-generator/ontology/fta-fmea-model.ttl
@@ -342,6 +342,11 @@ fta-fmea:is-artifact-of rdf:type owl:ObjectProperty ;
                   rdfs:label "is artifact of" .
 
 
+###  http://onto.fel.cvut.cz/ontologies/fta-fmea-application/has-operational-data-filter
+fta-fmea:has-operational-data-filter rdf:type owl:ObjectProperty .
+
+###  http://onto.fel.cvut.cz/ontologies/fta-fmea-application/has-global-operational-data-filter
+fta-fmea:has-global-operational-data-filter rdf:type owl:ObjectProperty .
 
 
 #################################################################
@@ -526,6 +531,10 @@ fta-fmea:subsystem-name rdf:type owl:DatatypeProperty ;
 fta-fmea:system-name rdf:type owl:DatatypeProperty ;
                   rdfs:label "system name" .
 
+
+###  http://onto.fel.cvut.cz/ontologies/fta-fmea-application/min-operational-hours
+    fta-fmea:min-operational-hours rdf:type owl:DatatypeProperty ;
+                      rdfs:label "Minimum operational hours" .
 
 #################################################################
 #    Classes
@@ -761,7 +770,11 @@ fta-fmea:verification-method rdf:type owl:Class ;
 
 ###  http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component-failure-type
 fta-fmea:sns-component-failure-type rdf:type owl:Class ;
-                                                                                                 rdfs:subClassOf fta-fmea:fault-event-type .
+   rdfs:subClassOf fta-fmea:fault-event-type .
+
+###  http://onto.fel.cvut.cz/ontologies/fta-fmea-application/operational-data-filter
+fta-fmea:operational-data-filter rdf:type owl:Class ;
+   rdfs:label "Operational data filter"@en .
 
 
 #################################################################

--- a/src/main/java/cz/cvut/kbss/analysis/config/conf/OperationalDataConfig.java
+++ b/src/main/java/cz/cvut/kbss/analysis/config/conf/OperationalDataConfig.java
@@ -1,0 +1,21 @@
+package cz.cvut.kbss.analysis.config.conf;
+
+import cz.cvut.kbss.analysis.util.ConfigParam;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Setter
+@Getter
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties("operational.data.filter")
+public class OperationalDataConfig {
+
+    protected Double minOperationalHours;
+
+}

--- a/src/main/java/cz/cvut/kbss/analysis/controller/FaultTreeController.java
+++ b/src/main/java/cz/cvut/kbss/analysis/controller/FaultTreeController.java
@@ -1,6 +1,7 @@
 package cz.cvut.kbss.analysis.controller;
 
 import cz.cvut.kbss.analysis.model.*;
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.service.FaultTreeRepositoryService;
 import cz.cvut.kbss.analysis.service.IdentifierService;
 import cz.cvut.kbss.analysis.util.Vocabulary;
@@ -129,10 +130,10 @@ public class FaultTreeController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping(value = "/{faultTreeFragment}/evaluate")
-    public void evaluate(@PathVariable(name = "faultTreeFragment") String faultTreeFragment){
+    public void evaluate(@PathVariable(name = "faultTreeFragment") String faultTreeFragment, @RequestBody OperationalDataFilter filter){
         URI faultTreeUri = identifierService.composeIdentifier(Vocabulary.s_c_fault_tree, faultTreeFragment);
         log.info("> performCutSetAnalysis - {}", faultTreeFragment);
-        repositoryService.evaluate(faultTreeUri);
+        repositoryService.evaluate(faultTreeUri, filter);
     }
 
 }

--- a/src/main/java/cz/cvut/kbss/analysis/controller/OperationalDataFilterController.java
+++ b/src/main/java/cz/cvut/kbss/analysis/controller/OperationalDataFilterController.java
@@ -1,0 +1,47 @@
+package cz.cvut.kbss.analysis.controller;
+
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
+import cz.cvut.kbss.analysis.service.IdentifierService;
+import cz.cvut.kbss.analysis.service.OperationalDataFilterService;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import cz.cvut.kbss.jsonld.JsonLd;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+
+import java.net.URI;
+
+@Controller("/operational-data-filter")
+@Slf4j
+public class OperationalDataFilterController {
+
+    private final OperationalDataFilterService filterService;
+    private final IdentifierService identifierService;
+
+    public OperationalDataFilterController(OperationalDataFilterService filterService, IdentifierService identifierService) {
+        this.filterService = filterService;
+        this.identifierService = identifierService;
+    }
+
+    @PutMapping(path="reset", produces = {JsonLd.MEDIA_TYPE, MediaType.APPLICATION_JSON_VALUE})
+    public void reset(){
+        filterService.removeFilter();
+    }
+
+    @PostMapping(value = "/system/{systemFragment}", consumes = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
+    public void updateSystemFilter(@PathVariable(name = "systemFragment") String systemFragment, OperationalDataFilter filter){
+        log.info("> updateSystemFilter - {} to {}", systemFragment, filter);
+        URI systemUri = identifierService.composeIdentifier(Vocabulary.s_c_system, systemFragment);
+        filterService.updateSystemFilter(systemUri, filter);
+    }
+
+    @PostMapping(value = "/fault-tree/{faultTreeFragment}", consumes = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
+    public void updateFaultTreeFilter(@PathVariable(name = "faultTreeFragment") String faultTreeFragment, OperationalDataFilter filter){
+        log.info("> updateFaultTreeFilter - {} to {}", faultTreeFragment, filter);
+        URI faultTreeUri = identifierService.composeIdentifier(Vocabulary.s_c_fault_tree, faultTreeFragment);
+        filterService.updateFaultTreeFilter(faultTreeUri, filter);
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/dao/BaseDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/BaseDao.java
@@ -37,7 +37,7 @@ public abstract class BaseDao<T extends AbstractEntity> implements GenericDao<T>
     }
 
     public EntityDescriptor getEntityDescriptor(T entity){
-        EntityDescriptor descriptor = new EntityDescriptor();
+        EntityDescriptor descriptor = new EntityDescriptor(entity.getContext());
         setEntityDescriptor(descriptor);
         return descriptor;
     }

--- a/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
@@ -1,0 +1,61 @@
+package cz.cvut.kbss.analysis.dao;
+
+import cz.cvut.kbss.analysis.config.conf.PersistenceConf;
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
+import cz.cvut.kbss.analysis.service.IdentifierService;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
+import org.springframework.stereotype.Repository;
+
+import java.net.URI;
+import java.util.Objects;
+
+@Repository
+public class OperationalDataFilterDao extends BaseDao<OperationalDataFilter> {
+
+    protected static final URI HAS_OPERATIONAL_DATA_FILTER_PROP = URI.create(Vocabulary.s_p_has_operational_data_filter);
+
+    public OperationalDataFilterDao( EntityManager em, PersistenceConf config, IdentifierService identifierService) {
+        super(OperationalDataFilter.class, em, config, identifierService);
+    }
+
+    public OperationalDataFilter findByEntity(URI entity) {
+        return em.createNativeQuery("""
+                SELECT ?uri WHERE {?entity ?hasOperationalDataFilter ?uri } LIMIT 1
+                """, OperationalDataFilter.class)
+                .setParameter("hasOperationalDataFilter", HAS_OPERATIONAL_DATA_FILTER_PROP)
+                .setParameter("entity", entity)
+                .getResultList().stream().findAny().orElse(null);
+    }
+
+    /**
+     * Associates the filter with the entityURI
+     * @param entityURI
+     * @param filter should have non-null uri and context
+     */
+    public void persistHasFilter(URI entityURI, OperationalDataFilter filter){
+
+        Objects.requireNonNull(entityURI);
+        Objects.requireNonNull(filter);
+        Objects.requireNonNull(filter.getUri());
+
+        em.createNativeQuery("""
+                INSERT {
+                    GRAPH ?context{
+                        ?entity ?hasOperationalDataFilter ?filter.
+                    }
+                }WHERE {}
+                """)
+                .setParameter("context", filter.getContext())
+                .setParameter("entity", entityURI)
+                .setParameter("hasOperationalDataFilter", HAS_OPERATIONAL_DATA_FILTER_PROP)
+                .setParameter("filter", filter.getUri())
+                .executeUpdate();
+    }
+
+    @Override
+    public EntityDescriptor getEntityDescriptor(URI uri) {
+        return super.getEntityDescriptor(uri);
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/model/FaultTree.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/FaultTree.java
@@ -1,5 +1,6 @@
 package cz.cvut.kbss.analysis.model;
 
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.util.Vocabulary;
 import cz.cvut.kbss.jopa.model.annotations.*;
 import jakarta.validation.constraints.NotNull;
@@ -26,13 +27,18 @@ public class FaultTree extends ManagedEntity {
     @Transient
     @OWLDataProperty(iri = Vocabulary.s_p_required_failure_rate)
     protected Double requiredFailureRate;
+
     @Transient
     @OWLDataProperty(iri = Vocabulary.s_p_calculated_failure_rate)
     protected Double calculatedFailureRate;
+
     @Transient
     @OWLDataProperty(iri = Vocabulary.s_p_fha_based_failure_rate)
     protected Double fhaBasedFailureRate;
 
+    @Transient
+    @OWLObjectProperty(iri = Vocabulary.s_p_has_operational_data_filter)
+    protected OperationalDataFilter operationalDataFilter;
 
     @NotNull(message = "Manifesting event must be chosen")
     @ParticipationConstraints(nonEmpty = true)

--- a/src/main/java/cz/cvut/kbss/analysis/model/System.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/System.java
@@ -1,7 +1,8 @@
 package cz.cvut.kbss.analysis.model;
 
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.util.Vocabulary;
-import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,6 +10,14 @@ import lombok.Setter;
 @Getter
 @Setter
 public class System extends Item {
+
+    @Transient
+    @OWLObjectProperty(iri = Vocabulary.s_p_has_global_operational_data_filter)
+    protected OperationalDataFilter globalOperationalDataFilter;
+
+    @Transient
+    @OWLObjectProperty(iri = Vocabulary.s_p_has_operational_data_filter)
+    protected OperationalDataFilter operationalDataFilter;
 
     @Override
     public String toString() {

--- a/src/main/java/cz/cvut/kbss/analysis/model/opdata/OperationalDataFilter.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/opdata/OperationalDataFilter.java
@@ -1,0 +1,21 @@
+package cz.cvut.kbss.analysis.model.opdata;
+
+import cz.cvut.kbss.analysis.model.AbstractEntity;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@OWLClass(iri = Vocabulary.s_c_operational_data_filter)
+@Getter
+@Setter
+public class OperationalDataFilter extends AbstractEntity {
+
+    @OWLDataProperty(iri = Vocabulary.s_p_min_operational_hours)
+    protected Double minOperationalHours;
+
+    public void setAs(OperationalDataFilter other){
+        this.minOperationalHours = other.getMinOperationalHours();
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
@@ -1,0 +1,118 @@
+package cz.cvut.kbss.analysis.service;
+
+import cz.cvut.kbss.analysis.config.conf.OperationalDataConfig;
+import cz.cvut.kbss.analysis.dao.GenericDao;
+import cz.cvut.kbss.analysis.dao.OperationalDataFilterDao;
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+
+@Service
+@Slf4j
+public class OperationalDataFilterService extends BaseRepositoryService<OperationalDataFilter> {
+
+
+    private final OperationalDataConfig defaultFilter;
+    private final OperationalDataFilterDao filterDao;
+
+    public OperationalDataFilterService(OperationalDataConfig defaultFilter, OperationalDataFilterDao filterDao) {
+        super(null);
+        this.defaultFilter = defaultFilter;
+        this.filterDao = filterDao;
+    }
+
+    /**
+     *
+     * @return default global filter configured by deployment parameters
+     */
+    public OperationalDataFilter getDefaultGlobalFilter(){
+        OperationalDataFilter filter = new OperationalDataFilter();
+        filter.setMinOperationalHours(defaultFilter.getMinOperationalHours());
+        return filter;
+    }
+
+    /**
+     *
+     * @param systemURI
+     * @return the aircraft operational data filter, if no filter is associated with the provided systemURI in
+     * persistent storage the current global filter is returned.
+     */
+    public OperationalDataFilter getSystemFilter(URI systemURI){
+        OperationalDataFilter filter = filterDao.findByEntity(systemURI);
+        if(filter == null){
+            filter = new OperationalDataFilter();
+            filter.setAs(getDefaultGlobalFilter());
+        }
+
+        return filter;
+    }
+
+    /**
+     *
+     * @param faultTreeURI
+     * @param systemURI
+     * @return operational data filter associated with faultTreeURI in persistent storage, if not present returns
+     * getSystemFilter(systemURI)
+     */
+
+    public OperationalDataFilter getFaultTreeFilter(URI faultTreeURI, URI systemURI){
+        OperationalDataFilter filter = filterDao.findByEntity(faultTreeURI);
+        if(filter == null){
+            filter = new OperationalDataFilter();
+            filter.setAs(getSystemFilter(systemURI));
+        }
+
+        return filter;
+    }
+
+    @Transactional
+    public void updateSystemFilter(URI systemURI, OperationalDataFilter newFilter){
+        URI context = URI.create(systemURI.toString() + "jopa");
+        updateFilter(systemURI, newFilter, context);
+    }
+
+    @Transactional
+    public void updateFaultTreeFilter(URI faultTreeURI, OperationalDataFilter newFilter){
+        updateFilter(faultTreeURI, newFilter, faultTreeURI);
+    }
+
+    public void updateFilter(URI entity, OperationalDataFilter newFilter, URI context){
+
+        Objects.requireNonNull(newFilter);
+        OperationalDataFilter filter = filterDao.findByEntity(entity);
+        if(filter != null) {
+            filter.setContext(context);
+            filterDao.update(filter);
+            filter.setAs(newFilter);
+            return;
+        }
+        filter = new OperationalDataFilter();
+        filter.setAs(newFilter);
+        filter.setContext(context);
+        persist(filter);
+        filterDao.persistHasFilter(entity, filter);
+    }
+
+    public void removeFilter(){
+        List<OperationalDataFilter> filters = findAll();
+        if(filters.isEmpty())
+            return;
+        for(OperationalDataFilter filter: filters)
+            filterDao.remove(filter);
+    }
+
+    @Override
+    protected GenericDao<OperationalDataFilter> getPrimaryDao() {
+        return filterDao;
+    }
+
+    @Override
+    protected void validate(OperationalDataFilter instance) {
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,6 @@ spring:
           issuer-uri: http://localhost/ava/services/auth/realms/record-manager
           jwt-set-uri: http://localhost/ava/services/auth/realms/record-manager/protocol/openid-connect/certs
 
+
+operational.data.filter:
+  min-operational-hours: 200


### PR DESCRIPTION
@blcham 
Related to kbss-cvut/fta-fmea-ui#310

Adds persistent min operational hours as property of OperationalDataFilter, integration with fault tree and ans system services and integration with fault tree rest api

Details
- global min operational hours configurable via deployment parameter
- system and fault tree summaries contain its own filter, system also contains global filter
- provide api to update system and fault tree specific operational data filters
- fault tree fetched with operational data filter
- fault tree evaluation persists operational data filter into its context
- system specific filter is persisted into system specific context