### PR TITLE
Feature/116 update fault tree operational failure rate

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/config/JacksonConfig.java
+++ b/src/main/java/cz/cvut/kbss/analysis/config/JacksonConfig.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.cvut.kbss.jsonld.ConfigParam;
 import cz.cvut.kbss.jsonld.jackson.JsonLdModule;
 import cz.cvut.kbss.jsonld.jackson.serialization.SerializationConstants;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class JacksonConfig {
@@ -22,4 +24,10 @@ public class JacksonConfig {
         return mapper;
     }
 
+    @Bean(name = "customRestTemplate")
+    public RestTemplate restTemplate() {
+        return new RestTemplateBuilder()
+//                .additionalMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper()))
+                .build();
+    }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/config/conf/OperationalDataConfig.java
+++ b/src/main/java/cz/cvut/kbss/analysis/config/conf/OperationalDataConfig.java
@@ -17,5 +17,10 @@ import org.springframework.core.env.Environment;
 public class OperationalDataConfig {
 
     protected Double minOperationalHours;
+    protected String operationalFailureRateService;
 
+    @Autowired
+    public OperationalDataConfig(Environment env) {
+        operationalFailureRateService = env.getProperty("operationalFailureRateService");
+    }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/dao/BaseDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/BaseDao.java
@@ -3,6 +3,7 @@ package cz.cvut.kbss.analysis.dao;
 import cz.cvut.kbss.analysis.config.conf.PersistenceConf;
 import cz.cvut.kbss.analysis.exception.PersistenceException;
 import cz.cvut.kbss.analysis.model.AbstractEntity;
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.model.util.EntityToOwlClassMapper;
 import cz.cvut.kbss.analysis.service.IdentifierService;
 import cz.cvut.kbss.jopa.model.EntityManager;
@@ -209,6 +210,30 @@ public abstract class BaseDao<T extends AbstractEntity> implements GenericDao<T>
                 .setParameter("predicate", URI.create(predicate))
                 .setParameter("value", value, config.getLanguage())
                 .getSingleResult();
+    }
+
+    /**
+     * Associates new object with subjectURI via property
+     * @param subjectURI
+     * @param object should have non-null uri and context
+     */
+    public void persistObject(URI subjectURI, URI property, AbstractEntity object){
+        Objects.requireNonNull(subjectURI);
+        Objects.requireNonNull(object);
+        Objects.requireNonNull(object.getUri());
+
+        em.createNativeQuery("""
+                INSERT {
+                    GRAPH ?context{
+                        ?subject ?hasOperationalDataFilter ?object.
+                    }
+                }WHERE {}
+                """)
+                .setParameter("context", object.getContext())
+                .setParameter("subject", subjectURI)
+                .setParameter("hasOperationalDataFilter", property)
+                .setParameter("object", object.getUri())
+                .executeUpdate();
     }
 
 }

--- a/src/main/java/cz/cvut/kbss/analysis/dao/FailureRateEstimateDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/FailureRateEstimateDao.java
@@ -1,0 +1,28 @@
+package cz.cvut.kbss.analysis.dao;
+
+import cz.cvut.kbss.analysis.config.conf.PersistenceConf;
+import cz.cvut.kbss.analysis.model.FailureRateEstimate;
+import cz.cvut.kbss.analysis.service.IdentifierService;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import cz.cvut.kbss.jopa.model.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.net.URI;
+
+@Repository
+public class FailureRateEstimateDao extends BaseDao<FailureRateEstimate>{
+    protected final static URI HAS_ESTIMATE_PROP = URI.create(Vocabulary.s_p_has_estimate);
+    protected final static URI VALUE_PROP = URI.create(Vocabulary.s_p_value);
+
+    public FailureRateEstimateDao(EntityManager em, PersistenceConf config, IdentifierService identifierService) {
+        super(FailureRateEstimate.class, em, config, identifierService);
+    }
+
+    public void setHasEstimate(URI failureRateUri, FailureRateEstimate estimate, URI context) {
+        addOrReplaceValue(failureRateUri, HAS_ESTIMATE_PROP, estimate.getUri(), context);
+    }
+
+    public void setValue(URI failureRateEstimateUri, Double value, URI context) {
+        addOrReplaceValue(failureRateEstimateUri, VALUE_PROP, value, context);
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/dao/FaultEventDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/FaultEventDao.java
@@ -17,6 +17,8 @@ import java.net.URI;
 @Repository
 public class FaultEventDao extends NamedEntityDao<FaultEvent> {
 
+    public static final URI PROBABILITY_PROP = URI.create(Vocabulary.s_p_probability);
+
     @Autowired
     protected FaultEventDao(EntityManager em, PersistenceConf config, IdentifierService identifierService) {
         super(FaultEvent.class, em, config, identifierService);
@@ -50,6 +52,10 @@ public class FaultEventDao extends NamedEntityDao<FaultEvent> {
         entityDescriptor.addAttributeContext(fe.getAttribute("behavior"), null);
 
         return entityDescriptor;
+    }
+
+    public void setProbability(URI faultEventUri, Double probability, URI context){
+        addOrReplaceValue(faultEventUri, PROBABILITY_PROP, probability, context);
     }
 
     public EntityDescriptor getRectangleDescriptor(URI uri){

--- a/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
@@ -35,23 +35,7 @@ public class OperationalDataFilterDao extends BaseDao<OperationalDataFilter> {
      * @param filter should have non-null uri and context
      */
     public void persistHasFilter(URI entityURI, OperationalDataFilter filter){
-
-        Objects.requireNonNull(entityURI);
-        Objects.requireNonNull(filter);
-        Objects.requireNonNull(filter.getUri());
-
-        em.createNativeQuery("""
-                INSERT {
-                    GRAPH ?context{
-                        ?entity ?hasOperationalDataFilter ?filter.
-                    }
-                }WHERE {}
-                """)
-                .setParameter("context", filter.getContext())
-                .setParameter("entity", entityURI)
-                .setParameter("hasOperationalDataFilter", HAS_OPERATIONAL_DATA_FILTER_PROP)
-                .setParameter("filter", filter.getUri())
-                .executeUpdate();
+        persistObject(entityURI, HAS_OPERATIONAL_DATA_FILTER_PROP, filter);
     }
 
     @Override

--- a/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/OperationalDataFilterDao.java
@@ -9,7 +9,6 @@ import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.util.Objects;
 
 @Repository
 public class OperationalDataFilterDao extends BaseDao<OperationalDataFilter> {
@@ -35,7 +34,7 @@ public class OperationalDataFilterDao extends BaseDao<OperationalDataFilter> {
      * @param filter should have non-null uri and context
      */
     public void persistHasFilter(URI entityURI, OperationalDataFilter filter){
-        persistObject(entityURI, HAS_OPERATIONAL_DATA_FILTER_PROP, filter);
+        addOrReplaceValue(entityURI, HAS_OPERATIONAL_DATA_FILTER_PROP, filter, filter.getContext());
     }
 
     @Override

--- a/src/main/java/cz/cvut/kbss/analysis/model/opdata/ItemFailureRate.java
+++ b/src/main/java/cz/cvut/kbss/analysis/model/opdata/ItemFailureRate.java
@@ -1,0 +1,32 @@
+package cz.cvut.kbss.analysis.model.opdata;
+
+import cz.cvut.kbss.jopa.model.annotations.*;
+
+import java.net.URI;
+
+
+@OWLClass(iri = "http://item-failure-rate")
+public class ItemFailureRate {
+
+    @Id
+    protected URI uri;
+
+    @OWLDataProperty(iri = "http://failureRate")
+    protected Double failureRate;
+
+    public URI getUri() {
+        return uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    public Double getFailureRate() {
+        return failureRate;
+    }
+
+    public void setFailureRate(Double failureRate) {
+        this.failureRate = failureRate;
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/BaseRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/BaseRepositoryService.java
@@ -271,4 +271,11 @@ public abstract class BaseRepositoryService<T extends HasIdentifier> {
         }
     }
 
+    public URI getToolContext(URI uri){
+        return getToolContext(uri.toString());
+    }
+
+    public URI getToolContext(String uri){
+        return URI.create(uri + "-jopa");
+    }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
@@ -73,7 +73,7 @@ public class OperationalDataFilterService extends BaseRepositoryService<Operatio
 
     @Transactional
     public void updateSystemFilter(URI systemURI, OperationalDataFilter newFilter){
-        URI context = URI.create(systemURI.toString() + "jopa");
+        URI context = URI.create(systemURI.toString() + "-jopa");
         updateFilter(systemURI, newFilter, context);
     }
 

--- a/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
@@ -73,7 +73,7 @@ public class OperationalDataFilterService extends BaseRepositoryService<Operatio
 
     @Transactional
     public void updateSystemFilter(URI systemURI, OperationalDataFilter newFilter){
-        URI context = URI.create(systemURI.toString() + "-jopa");
+        URI context = getToolContext(systemURI);
         updateFilter(systemURI, newFilter, context);
     }
 

--- a/src/main/java/cz/cvut/kbss/analysis/service/external/OperationalDataService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/external/OperationalDataService.java
@@ -1,0 +1,38 @@
+package cz.cvut.kbss.analysis.service.external;
+
+import cz.cvut.kbss.analysis.config.conf.OperationalDataConfig;
+import cz.cvut.kbss.analysis.model.opdata.ItemFailureRate;
+import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
+import cz.cvut.kbss.analysis.service.OperationalDataFilterService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@Slf4j
+public class OperationalDataService {
+
+    private final OperationalDataConfig operationalDataConfig;
+    private final OperationalDataFilterService service;
+    private final RestTemplate restTemplate;
+
+
+    public OperationalDataService(OperationalDataConfig operationalDataConfig, OperationalDataFilterService service, @Qualifier("customRestTemplate") RestTemplate restTemplate) {
+        this.operationalDataConfig = operationalDataConfig;
+        this.service = service;
+        this.restTemplate = restTemplate;
+    }
+
+    public ItemFailureRate[] fetchFailureRates(OperationalDataFilter filter, Collection<URI> components){
+        String apiURI = operationalDataConfig.getOperationalFailureRateService();
+        Map<String, Object> uriParams = new HashMap<>();
+        uriParams.put("minOperationalTime", filter.getMinOperationalHours());
+        return restTemplate.postForObject(apiURI, components, ItemFailureRate[].class, uriParams);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,3 +40,5 @@ spring:
 
 operational.data.filter:
   min-operational-hours: 200
+
+operationalFailureRateService: https://kbss.onto.fel.cvut.cz/ava/services/ava-analytics/stats/failire-rate


### PR DESCRIPTION
@blcham 
Fixes #116
- Implements call to operation failure rate service configured in deployment parameters
- Implements API that updates a specified fault tree with operational failure rate retrieved from the operation failure rate service 