### PR TITLE
Store failure rate estimate in context common for all systems

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/dao/FailureRateDao.java
+++ b/src/main/java/cz/cvut/kbss/analysis/dao/FailureRateDao.java
@@ -1,0 +1,24 @@
+package cz.cvut.kbss.analysis.dao;
+
+import cz.cvut.kbss.analysis.config.conf.PersistenceConf;
+import cz.cvut.kbss.analysis.model.FailureRate;
+import cz.cvut.kbss.analysis.service.IdentifierService;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import cz.cvut.kbss.jopa.model.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.net.URI;
+
+@Repository
+public class FailureRateDao extends BaseDao<FailureRate> {
+    public static final URI HAS_FAILURE_RATE_PROP = URI.create(Vocabulary.s_p_has_failure_rate);
+
+    public FailureRateDao(EntityManager em, PersistenceConf config, IdentifierService identifierService) {
+        super(FailureRate.class, em, config, identifierService);
+    }
+
+    public void setFailureRate(URI eventUri, FailureRate fr, URI context){
+        addOrReplaceValue(eventUri, HAS_FAILURE_RATE_PROP, fr.getUri(), context);
+
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/SystemRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/SystemRepositoryService.java
@@ -10,6 +10,7 @@ import cz.cvut.kbss.analysis.model.Item;
 import cz.cvut.kbss.analysis.model.System;
 import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
+import cz.cvut.kbss.analysis.util.Vocabulary;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -25,6 +26,8 @@ import java.util.Set;
 @Service
 @Slf4j
 public class SystemRepositoryService extends ComplexManagedEntityRepositoryService<System> {
+
+    public static final URI GENERAL_SYSTEM_CONTEXT = URI.create(Vocabulary.s_c_ata_system + "/tool-context");
 
     private final SystemDao systemDao;
     private final ComponentRepositoryService componentRepositoryService;
@@ -136,6 +139,10 @@ public class SystemRepositoryService extends ComplexManagedEntityRepositoryServi
         OperationalDataFilter filter = operationalDataFilterService.getSystemFilter(system.getUri());
         system.setOperationalDataFilter(filter);
         system.setGlobalOperationalDataFilter(operationalDataFilterService.getDefaultGlobalFilter());
+    }
+
+    public URI getToolContextForGeneralSystem(URI uri){
+        return GENERAL_SYSTEM_CONTEXT;
     }
 
 }


### PR DESCRIPTION
@blcham 
Fix partially  kbss-cvut/fta-fmea-ui#492 

Store failure rate estimate in context common for all systems.
Also create failure rate object if missing, store it in common system context.