### PR TITLE
Extend validation api

### DIFF
--- a/src/main/java/cz/cvut/kbss/analysis/service/ComplexManagedEntityRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/ComplexManagedEntityRepositoryService.java
@@ -6,9 +6,9 @@ import cz.cvut.kbss.analysis.dao.UserDao;
 import cz.cvut.kbss.analysis.model.ManagedEntity;
 import cz.cvut.kbss.analysis.model.UserReference;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.NonNull;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -24,7 +24,7 @@ public abstract class ComplexManagedEntityRepositoryService<T extends ManagedEnt
     protected final UserDao userDao;
     protected final SecurityUtils securityUtils;
 
-    public ComplexManagedEntityRepositoryService(Validator validator, UserDao userDao, SecurityUtils securityUtils) {
+    public ComplexManagedEntityRepositoryService(EntityValidator validator, UserDao userDao, SecurityUtils securityUtils) {
         super(validator);
         this.userDao = userDao;
         this.securityUtils = securityUtils;

--- a/src/main/java/cz/cvut/kbss/analysis/service/ComponentRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/ComponentRepositoryService.java
@@ -6,12 +6,12 @@ import cz.cvut.kbss.analysis.dto.update.ComponentUpdateDTO;
 import cz.cvut.kbss.analysis.model.Component;
 import cz.cvut.kbss.analysis.model.FailureMode;
 import cz.cvut.kbss.analysis.model.Function;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -26,7 +26,7 @@ public class ComponentRepositoryService extends BaseRepositoryService<Component>
     private final FunctionRepositoryService functionService;
 
     @Autowired
-    public ComponentRepositoryService(@Qualifier("componentValidator") Validator validator, ComponentDao componentDao
+    public ComponentRepositoryService(@Qualifier("componentValidator") EntityValidator validator, ComponentDao componentDao
             , FailureModeRepositoryService failureModeRepositoryService, FunctionRepositoryService functionService) {
         super(validator);
         this.componentDao = componentDao;
@@ -113,6 +113,8 @@ public class ComponentRepositoryService extends BaseRepositoryService<Component>
     @Transactional
     public FailureMode addFailureMode(URI componentUri, FailureMode failureMode) {
         log.info("> addFailureMode - {}, {}", componentUri, failureMode);
+
+        failureModeRepositoryService.validateNew(failureMode);
 
         Component component = findRequired(componentUri);
         component.addFailureMode(failureMode);

--- a/src/main/java/cz/cvut/kbss/analysis/service/FailureModeRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FailureModeRepositoryService.java
@@ -3,16 +3,14 @@ package cz.cvut.kbss.analysis.service;
 import cz.cvut.kbss.analysis.dao.FailureModeDao;
 import cz.cvut.kbss.analysis.dao.GenericDao;
 import cz.cvut.kbss.analysis.model.FailureMode;
-import cz.cvut.kbss.analysis.model.Function;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
-import java.util.HashSet;
 import java.util.Set;
 
 @Service
@@ -23,7 +21,7 @@ public class FailureModeRepositoryService extends BaseRepositoryService<FailureM
     private final FunctionRepositoryService functionRepositoryService;
 
     @Autowired
-    public FailureModeRepositoryService(@Qualifier("defaultValidator") Validator validator, FailureModeDao failureModeDao, FunctionRepositoryService functionRepositoryService) {
+    public FailureModeRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator, FailureModeDao failureModeDao, FunctionRepositoryService functionRepositoryService) {
         super(validator);
         this.failureModeDao = failureModeDao;
         this.functionRepositoryService = functionRepositoryService;

--- a/src/main/java/cz/cvut/kbss/analysis/service/FailureModesRowRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FailureModesRowRepositoryService.java
@@ -5,12 +5,12 @@ import cz.cvut.kbss.analysis.dao.GenericDao;
 import cz.cvut.kbss.analysis.dto.update.FailureModesRowRpnUpdateDTO;
 import cz.cvut.kbss.analysis.model.FailureModesRow;
 import cz.cvut.kbss.analysis.model.Mitigation;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 
@@ -22,8 +22,8 @@ public class FailureModesRowRepositoryService extends BaseRepositoryService<Fail
     private final MitigationRepositoryService mitigationRepositoryService;
 
     @Autowired
-    public FailureModesRowRepositoryService(@Qualifier("defaultValidator") Validator validator, FailureModesRowDao failureModesRowDao
-            ,MitigationRepositoryService mitigationRepositoryService) {
+    public FailureModesRowRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator, FailureModesRowDao failureModesRowDao
+            , MitigationRepositoryService mitigationRepositoryService) {
         super(validator);
         this.failureModesRowDao = failureModesRowDao;
         this.mitigationRepositoryService = mitigationRepositoryService;

--- a/src/main/java/cz/cvut/kbss/analysis/service/FailureModesTableRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FailureModesTableRepositoryService.java
@@ -9,13 +9,13 @@ import cz.cvut.kbss.analysis.dto.update.FailureModesTableUpdateDTO;
 import cz.cvut.kbss.analysis.model.*;
 import cz.cvut.kbss.analysis.service.util.FaultTreeTraversalUtils;
 import cz.cvut.kbss.analysis.service.util.Pair;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.io.StringWriter;
 import java.net.URI;
@@ -33,7 +33,7 @@ public class FailureModesTableRepositoryService extends BaseRepositoryService<Fa
     private final FunctionRepositoryService functionRepositoryService;
 
     @Autowired
-    public FailureModesTableRepositoryService(@Qualifier("defaultValidator") Validator validator,
+    public FailureModesTableRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator,
                                               FailureModesTableDao failureModesTableDao,
                                               FaultEventRepositoryService faultEventRepositoryService,
                                               FunctionRepositoryService functionRepositoryService) {

--- a/src/main/java/cz/cvut/kbss/analysis/service/FaultEventRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FaultEventRepositoryService.java
@@ -10,6 +10,7 @@ import cz.cvut.kbss.analysis.model.diagram.Rectangle;
 import cz.cvut.kbss.analysis.model.fta.FtaEventType;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
 import cz.cvut.kbss.analysis.service.strategy.DirectFtaEvaluation;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import cz.cvut.kbss.analysis.util.Vocabulary;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.util.*;
@@ -39,7 +39,7 @@ public class FaultEventRepositoryService extends BaseRepositoryService<FaultEven
     private final SecurityUtils securityUtils;
 
     @Autowired
-    public FaultEventRepositoryService(@Qualifier("faultEventValidator") Validator validator, FaultEventDao faultEventDao, ComponentRepositoryService componentRepositoryService, FaultTreeDao faultTreeDao, FaultEventTypeService faultEventTypeService, FaultEventTypeDao faultEventTypeDao, SecurityUtils securityUtils) {
+    public FaultEventRepositoryService(@Qualifier("faultEventValidator") EntityValidator validator, FaultEventDao faultEventDao, ComponentRepositoryService componentRepositoryService, FaultTreeDao faultTreeDao, FaultEventTypeService faultEventTypeService, FaultEventTypeDao faultEventTypeDao, SecurityUtils securityUtils) {
         super(validator);
         this.faultEventDao = faultEventDao;
         this.componentRepositoryService = componentRepositoryService;
@@ -62,6 +62,7 @@ public class FaultEventRepositoryService extends BaseRepositoryService<FaultEven
 
     @Transactional
     public FaultEvent addInputEvent(URI eventUri, FaultEvent inputEvent) {
+        validateNew(inputEvent);
         FaultEvent currentEvent = findRequired(eventUri);
 
         if(inputEvent.getUri() == null && inputEvent.getRectangle() == null)

--- a/src/main/java/cz/cvut/kbss/analysis/service/FaultEventTypeService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FaultEventTypeService.java
@@ -84,6 +84,6 @@ public class FaultEventTypeService extends BaseRepositoryService<FaultEventType>
     }
 
     @Override
-    protected void validate(FaultEventType instance) {
+    public void validate(FaultEventType instance, Object ... groups) {
     }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/FaultTreeRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FaultTreeRepositoryService.java
@@ -4,8 +4,8 @@ import cz.cvut.kbss.analysis.controller.util.PagingUtils;
 import cz.cvut.kbss.analysis.dao.*;
 import cz.cvut.kbss.analysis.dao.util.FaultTreeFilterParams;
 import cz.cvut.kbss.analysis.exception.EntityNotFoundException;
-import cz.cvut.kbss.analysis.model.*;
 import cz.cvut.kbss.analysis.model.System;
+import cz.cvut.kbss.analysis.model.*;
 import cz.cvut.kbss.analysis.model.ava.ATASystem;
 import cz.cvut.kbss.analysis.model.ava.FHAEventType;
 import cz.cvut.kbss.analysis.model.diagram.Rectangle;
@@ -19,6 +19,7 @@ import cz.cvut.kbss.analysis.service.external.OperationalDataService;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
 import cz.cvut.kbss.analysis.service.util.FaultTreeTraversalUtils;
 import cz.cvut.kbss.analysis.service.util.Pair;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import cz.cvut.kbss.analysis.util.Vocabulary;
 import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +30,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -56,7 +56,7 @@ public class FaultTreeRepositoryService extends ComplexManagedEntityRepositorySe
     private final FailureRateDao failureRateDao;
 
     @Autowired
-    public FaultTreeRepositoryService(@Qualifier("defaultValidator") Validator validator,
+    public FaultTreeRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator,
                                       FaultTreeDao faultTreeDao,
                                       FaultEventScenarioDao faultEventScenarioDao,
                                       FaultEventRepositoryService faultEventRepositoryService,

--- a/src/main/java/cz/cvut/kbss/analysis/service/FunctionRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/FunctionRepositoryService.java
@@ -6,15 +6,18 @@ import cz.cvut.kbss.analysis.dao.GenericDao;
 import cz.cvut.kbss.analysis.model.Behavior;
 import cz.cvut.kbss.analysis.model.Component;
 import cz.cvut.kbss.analysis.model.Function;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -24,7 +27,7 @@ public class FunctionRepositoryService extends BaseRepositoryService<Function> {
     private final FailureModeDao failureModeDao;
 
     @Autowired
-    public FunctionRepositoryService(@Qualifier("functionValidator") Validator validator, FunctionDao functionDao, FailureModeDao failureModeDao) {
+    public FunctionRepositoryService(@Qualifier("functionValidator") EntityValidator validator, FunctionDao functionDao, FailureModeDao failureModeDao) {
         super(validator);
         this.functionDao = functionDao;
         this.failureModeDao = failureModeDao;

--- a/src/main/java/cz/cvut/kbss/analysis/service/MitigationRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/MitigationRepositoryService.java
@@ -4,12 +4,12 @@ import cz.cvut.kbss.analysis.dao.GenericDao;
 import cz.cvut.kbss.analysis.dao.MitigationDao;
 import cz.cvut.kbss.analysis.dto.update.MitigationUpdateDTO;
 import cz.cvut.kbss.analysis.model.Mitigation;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 
@@ -17,10 +17,10 @@ import java.net.URI;
 @Service
 public class MitigationRepositoryService extends BaseRepositoryService<Mitigation> {
 
-    private MitigationDao mitigationDao;
+    private final MitigationDao mitigationDao;
 
     @Autowired
-    public MitigationRepositoryService(@Qualifier("defaultValidator") Validator validator, MitigationDao mitigationDao) {
+    public MitigationRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator, MitigationDao mitigationDao) {
         super(validator);
         this.mitigationDao = mitigationDao;
     }

--- a/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/OperationalDataFilterService.java
@@ -114,6 +114,6 @@ public class OperationalDataFilterService extends BaseRepositoryService<Operatio
     }
 
     @Override
-    protected void validate(OperationalDataFilter instance) {
+    public void validate(OperationalDataFilter instance, Object ... groups) {
     }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/SystemRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/SystemRepositoryService.java
@@ -11,6 +11,7 @@ import cz.cvut.kbss.analysis.model.Item;
 import cz.cvut.kbss.analysis.model.System;
 import cz.cvut.kbss.analysis.model.opdata.OperationalDataFilter;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import cz.cvut.kbss.analysis.util.Vocabulary;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -37,7 +37,7 @@ public class SystemRepositoryService extends ComplexManagedEntityRepositoryServi
     private final OperationalDataFilterService operationalDataFilterService;
 
     @Autowired
-    public SystemRepositoryService(@Qualifier("defaultValidator") Validator validator,
+    public SystemRepositoryService(@Qualifier("systemValidator") EntityValidator validator,
                                    SystemDao systemDao,
                                    ComponentRepositoryService componentRepositoryService,
                                    ComponentDao componentDao,
@@ -69,12 +69,6 @@ public class SystemRepositoryService extends ComplexManagedEntityRepositoryServi
 
     @Transactional
     public System create(System system){
-        List<URI> existingSystems = systemDao.findUriByName(system.getName());
-        if(!existingSystems.isEmpty())
-            throw new LogicViolationException((
-                    "Cannot create system with name \"%s\", " +
-                            "the name is already assigned to another system.")
-                    .formatted(system.getName()));
         this.persist(system);
         return system;
     }
@@ -96,12 +90,6 @@ public class SystemRepositoryService extends ComplexManagedEntityRepositoryServi
     @Transactional
     public System rename(System systemRename) {
         log.info("> rename - {}", systemRename);
-        List<URI> existingSystems = systemDao.findUriByName(systemRename.getName());
-        if(!existingSystems.isEmpty())
-            throw new LogicViolationException((
-                    "Cannot rename system to \"%s\", " +
-                            "the name is already assigned to another system.")
-                    .formatted(systemRename.getName()));
 
         System system = findRequired(systemRename.getUri());
         system.setName(systemRename.getName());

--- a/src/main/java/cz/cvut/kbss/analysis/service/UserRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/UserRepositoryService.java
@@ -7,13 +7,13 @@ import cz.cvut.kbss.analysis.exception.LogicViolationException;
 import cz.cvut.kbss.analysis.exception.UsernameNotAvailableException;
 import cz.cvut.kbss.analysis.model.User;
 import cz.cvut.kbss.analysis.service.security.SecurityUtils;
+import cz.cvut.kbss.analysis.service.validation.EntityValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.Validator;
 
 import java.net.URI;
 import java.util.Optional;
@@ -27,7 +27,7 @@ public class UserRepositoryService extends BaseRepositoryService<User> {
     private final SecurityUtils securityUtils;
 
     @Autowired
-    public UserRepositoryService(@Qualifier("defaultValidator") Validator validator, UserDao userDao, PasswordEncoder passwordEncoder, SecurityUtils securityUtils) {
+    public UserRepositoryService(@Qualifier("defaultEntityValidator") EntityValidator validator, UserDao userDao, PasswordEncoder passwordEncoder, SecurityUtils securityUtils) {
         super(validator);
         this.userDao = userDao;
         this.passwordEncoder = passwordEncoder;

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/ComponentValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/ComponentValidator.java
@@ -1,40 +1,26 @@
 package cz.cvut.kbss.analysis.service.validation;
 
+import cz.cvut.kbss.analysis.dao.BaseDao;
 import cz.cvut.kbss.analysis.dao.ComponentDao;
 import cz.cvut.kbss.analysis.model.Component;
-import cz.cvut.kbss.analysis.util.Vocabulary;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.validation.Errors;
-import org.springframework.validation.Validator;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 
 @Qualifier("componentValidator")
 @Slf4j
 @org.springframework.stereotype.Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class ComponentValidator implements Validator {
+public class ComponentValidator extends NamedEntityValidator<Component> {
 
     private final ComponentDao componentDao;
-    private final SpringValidatorAdapter validatorAdapter;
 
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return Component.class.isAssignableFrom(clazz);
+    public ComponentValidator(SpringValidatorAdapter validatorAdapter, ComponentDao componentDao) {
+        super(Component.class, validatorAdapter);
+        this.componentDao = componentDao;
     }
 
     @Override
-    public void validate(Object target, Errors errors) {
-        validatorAdapter.validate(target, errors);
-
-        Component instance = (Component) target;
-
-        boolean duplicate = componentDao.existsWithPredicate(Vocabulary.s_p_name, instance.getName());
-        if(instance.getUri() == null && duplicate) {
-            errors.rejectValue("name", "name.duplicate", "Duplicate component name");
-        }
+    protected BaseDao<Component> getPrimaryDao() {
+        return componentDao;
     }
-
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/DefaultEntityValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/DefaultEntityValidator.java
@@ -1,0 +1,28 @@
+package cz.cvut.kbss.analysis.service.validation;
+
+import cz.cvut.kbss.analysis.dao.BaseDao;
+import cz.cvut.kbss.analysis.model.NamedEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.validation.Errors;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+@Qualifier("defaultEntityValidator")
+@Slf4j
+@org.springframework.stereotype.Component
+public class DefaultEntityValidator extends NamedEntityValidator{
+
+    public DefaultEntityValidator(SpringValidatorAdapter validatorAdapter) {
+        super(NamedEntity.class, validatorAdapter);
+    }
+
+    @Override
+    protected BaseDao getPrimaryDao() {
+        return null;
+    }
+
+    @Override
+    protected void customValidation(Object target, Errors errors, Object... validationHints) {
+        // No custom validation
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/EntityValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/EntityValidator.java
@@ -1,0 +1,9 @@
+package cz.cvut.kbss.analysis.service.validation;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+public interface EntityValidator extends Validator {
+
+    void validate(Object target, Errors errors, Object... validationHints);
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/FaultTreeValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/FaultTreeValidator.java
@@ -1,50 +1,27 @@
 package cz.cvut.kbss.analysis.service.validation;
 
-import cz.cvut.kbss.analysis.dao.FaultEventDao;
-import cz.cvut.kbss.analysis.model.FaultEvent;
-import cz.cvut.kbss.analysis.model.fta.FtaEventType;
-import cz.cvut.kbss.analysis.model.fta.GateType;
-import cz.cvut.kbss.analysis.util.Vocabulary;
-import lombok.RequiredArgsConstructor;
+import cz.cvut.kbss.analysis.dao.BaseDao;
+import cz.cvut.kbss.analysis.dao.FaultTreeDao;
+import cz.cvut.kbss.analysis.model.FaultTree;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
-import org.springframework.validation.Validator;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 
 @Qualifier("faultTreeValidator")
 @Slf4j
 @Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class FaultTreeValidator implements Validator {
+public class FaultTreeValidator extends NamedEntityValidator<FaultTree> {
 
-    private final FaultEventDao faultEventDao;
-    private final SpringValidatorAdapter validatorAdapter;
+    private final FaultTreeDao faultTreeDao;
 
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return FaultEvent.class.isAssignableFrom(clazz);
+    public FaultTreeValidator(SpringValidatorAdapter validatorAdapter, FaultTreeDao faultTreeDao) {
+        super(FaultTree.class, validatorAdapter);
+        this.faultTreeDao = faultTreeDao;
     }
 
     @Override
-    public void validate(Object target, Errors errors) {
-        validatorAdapter.validate(target, errors);
-
-        FaultEvent instance = (FaultEvent) target;
-
-        boolean duplicate = faultEventDao.existsWithPredicate(Vocabulary.s_p_name, instance.getName());
-        if(instance.getUri() == null && duplicate) {
-            errors.rejectValue("name", "name.duplicate");
-        }
-
-        if (instance.getEventType() == FtaEventType.INTERMEDIATE && (instance.getGateType() == null || instance.getGateType() == GateType.UNUSED)) {
-            errors.rejectValue("gateType", "gateType.invalid");
-        }
-
-        if (instance.getEventType() != FtaEventType.INTERMEDIATE && (instance.getGateType() != null || instance.getGateType() != GateType.UNUSED)) {
-            errors.rejectValue("gateType", "gateType.invalid");
-        }
+    protected BaseDao<FaultTree> getPrimaryDao() {
+        return faultTreeDao;
     }
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/FunctionValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/FunctionValidator.java
@@ -1,40 +1,28 @@
 package cz.cvut.kbss.analysis.service.validation;
 
+import cz.cvut.kbss.analysis.dao.BaseDao;
 import cz.cvut.kbss.analysis.dao.FunctionDao;
 import cz.cvut.kbss.analysis.model.Function;
-import cz.cvut.kbss.analysis.util.Vocabulary;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.validation.Errors;
-import org.springframework.validation.Validator;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 
 @Qualifier("functionValidator")
 @Slf4j
-@org.springframework.stereotype.Component
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
-public class FunctionValidator implements Validator {
+@Component
+public class FunctionValidator extends NamedEntityValidator<Function> {
 
     private final FunctionDao functionDao;
-    private final SpringValidatorAdapter validatorAdapter;
 
-    @Override
-    public boolean supports(Class<?> clazz) {
-        return Function.class.isAssignableFrom(clazz);
+    public FunctionValidator(SpringValidatorAdapter validatorAdapter, FunctionDao functionDao) {
+        super(Function.class, validatorAdapter);
+        this.functionDao = functionDao;
     }
 
     @Override
-    public void validate(Object target, Errors errors) {
-        validatorAdapter.validate(target, errors);
-
-        Function instance = (Function) target;
-
-        boolean duplicate = functionDao.existsWithPredicate(Vocabulary.s_p_name, instance.getName());
-        if(instance.getUri() == null && duplicate) {
-            errors.rejectValue("name", "name.duplicate", "Duplicate component name");
-        }
+    protected BaseDao<Function> getPrimaryDao() {
+        return functionDao;
     }
 
 }

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/NamedEntityValidator.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/NamedEntityValidator.java
@@ -1,0 +1,101 @@
+package cz.cvut.kbss.analysis.service.validation;
+
+import cz.cvut.kbss.analysis.dao.BaseDao;
+import cz.cvut.kbss.analysis.model.NamedEntity;
+import cz.cvut.kbss.analysis.service.validation.groups.ValidationScopes;
+import cz.cvut.kbss.analysis.util.Vocabulary;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.Errors;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public abstract class NamedEntityValidator<T extends NamedEntity> implements EntityValidator {
+
+    protected final Class<T> supporetedClass;
+    protected final SpringValidatorAdapter validatorAdapter;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        Validator v;
+
+        return supporetedClass.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors, Object... validationHints) {
+        validatorAdapter.validate(target, errors, validationHints);
+        customValidation(target, errors, validationHints);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        validatorAdapter.validate(target, errors);
+        customValidation(target, errors);
+    }
+
+    protected abstract BaseDao<T> getPrimaryDao();
+
+    protected void customValidation(Object target, Errors errors, Object... validationHints ){
+        ConstraintGroupsAdapter groups = new ConstraintGroupsAdapter(validationHints);
+        NamedEntity entity = (NamedEntity) target;
+
+        if(existsWithName(entity))
+            errors.rejectValue("name", "name.duplicate", "Duplicate entity name");
+
+        if(groups.isCreateGroup() && exists(entity)){
+            errors.rejectValue("uri", "uri.exists", "The uri should be null or unique");
+        }
+        if(groups.isUpdateGroup() && !exists(entity)){
+            errors.rejectValue("uri", "uri.not-exists", "Uri does not refer to an existing entity");
+        }
+    }
+
+    protected boolean exists(NamedEntity entity){
+        return entity.getUri() != null && getPrimaryDao().exists(entity.getUri());
+    }
+
+    protected boolean existsWithName(NamedEntity entity){
+        return existsWithName(entity.getName());
+    }
+
+    protected boolean existsWithName(String name){
+        return name != null && !name.isBlank() &&
+                getPrimaryDao().existsWithPredicate(Vocabulary.s_p_name, name);
+    }
+
+    static class ConstraintGroupsAdapter{
+        Set<Class> groups;
+
+        public ConstraintGroupsAdapter(Object... groups) {
+            this.groups = classSet(groups);
+        }
+
+        public Set<Class> classSet(Object... groups){
+            return Stream.of(groups)
+                    .filter(o -> o != null)
+                    .filter(o -> o instanceof Class)
+                    .map(o -> (Class<?>)o)
+                    .collect(Collectors.toSet());
+        }
+
+        public boolean matchesAll(Object ... groups) {
+            if(groups.length == 0) return true;
+            return classSet(groups).stream().allMatch(t -> this.groups.stream().anyMatch(g -> g.isAssignableFrom(t)));
+        }
+
+        public boolean isCreateGroup() {
+            return matchesAll(ValidationScopes.Create.class);
+        }
+        public boolean isUpdateGroup() {
+            return matchesAll(ValidationScopes.Update.class);
+        }
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/ValidatorsConfiguration.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/ValidatorsConfiguration.java
@@ -1,0 +1,37 @@
+package cz.cvut.kbss.analysis.service.validation;
+
+import cz.cvut.kbss.analysis.dao.*;
+import cz.cvut.kbss.analysis.model.System;
+import cz.cvut.kbss.analysis.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
+
+@Configuration
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class ValidatorsConfiguration {
+
+    private final SpringValidatorAdapter validatorAdapter;
+
+    @Bean("systemValidator")
+    public NamedEntityValidator<System> systemValidator(SystemDao dao){
+        return createCommonValidator(System.class, dao);
+    }
+
+    @Bean(name ="failureModeValidator")
+    public NamedEntityValidator<FailureMode> failureModeValidator(FailureModeDao dao){
+        return createCommonValidator(FailureMode.class, dao);
+    }
+
+    protected <T extends NamedEntity> NamedEntityValidator<T> createCommonValidator(Class<T> cls, BaseDao<T> dao){
+        return new NamedEntityValidator<T>(cls, validatorAdapter) {
+            private final BaseDao<T> baseDao = dao;
+            @Override
+            protected BaseDao<T> getPrimaryDao() {
+                return baseDao;
+            }
+        };
+    }
+}

--- a/src/main/java/cz/cvut/kbss/analysis/service/validation/groups/ValidationScopes.java
+++ b/src/main/java/cz/cvut/kbss/analysis/service/validation/groups/ValidationScopes.java
@@ -1,0 +1,6 @@
+package cz.cvut.kbss.analysis.service.validation.groups;
+
+public interface ValidationScopes {
+    interface Create {}
+    interface Update {}
+}


### PR DESCRIPTION
@blcham 
- Support groups (validation constraint scopes, e.g. validations constraints when creating a new entity or updating an existing entity might differ)
- validators can be extended, e.g. `NamedEntityValidator` is extended by `FaultEventValidator` introducing validation constraints specific to `FaultEvent` entities.
- supports uri already exists constraint for new entities as suggested in [comment](https://github.com/kbss-cvut/fta-fmea/pull/150#discussion_r1741874656) in PR #150 